### PR TITLE
Add margin to welcome view widget

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -116,6 +116,8 @@ public class Eddy.MainWindow : Gtk.Window {
         main_extension = helper.resolve_extension_for_mime_types (Application.supported_mimetypes);
 
         welcome_view = new Granite.Widgets.Welcome (_("Install some apps"), _("Drag and drop .%s files or open them to begin installation.").printf (main_extension));
+        welcome_view.margin_left = 6;
+        welcome_view.margin_right = 6;
         open_index = welcome_view.append ("document-open", _("Open"), _("Browse to open a single file"));
         welcome_view.activated.connect (on_welcome_view_activated);
 


### PR DESCRIPTION
Adds a bit of margin to the left and right of the welcome widget to avoid text being against the side of the window like so:

![screenshot from 2017-08-24 10 56 32](https://user-images.githubusercontent.com/3385679/29680917-eca80a52-88ba-11e7-8bc5-05c74f53888c.png)

