### PR TITLE
Update Japanese translation

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -7,317 +7,327 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-09-10 15:31+0200\n"
-"PO-Revision-Date: 2018-05-23 19:33+0900\n"
+"POT-Creation-Date: 2018-12-18 22:35+0900\n"
+"PO-Revision-Date: 2018-12-18 22:25+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
+"Language-Team: \n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: Ryo Nakano <ryonakaknock@gmail.com>\n"
-"Language-Team: \n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.2\n"
 
-#: ../src/PackageListView.vala:49 ../src/PackageRow.vala:165
-msgid "Install"
-msgstr "インストール"
-
-#: ../src/PackageListView.vala:153
-msgid "Total installed size: %s"
-msgstr "合計インストールサイズ: %s"
-
-#: ../src/Application.vala:42
-msgid "translator-credits"
-msgstr ""
-
-#: ../src/Package.vala:190
-msgid "Starting"
-msgstr "開始しています"
-
-#: ../src/Package.vala:192
-msgid "Waiting"
-msgstr "待機しています"
-
-#: ../src/Package.vala:194
-msgid "Running"
-msgstr "実行しています"
-
-#: ../src/Package.vala:196
-msgid "Querying"
-msgstr "問い合わせしています"
-
-#: ../src/Package.vala:198
-msgid "Getting information"
-msgstr "情報を取得しています"
-
-#: ../src/Package.vala:200
-msgid "Removing packages"
-msgstr "パッケージを削除しています"
-
-#: ../src/Package.vala:202
-msgid "Downloading"
-msgstr "ダウンロードしています"
-
-#: ../src/Package.vala:204
-msgid "Refreshing software list"
-msgstr "ソフトウェアリストを更新しています"
-
-#: ../src/Package.vala:206
-msgid "Installing updates"
-msgstr "アップデートをインストールしています"
-
-#: ../src/Package.vala:208
-msgid "Cleaning up packages"
-msgstr "パッケージをクリーンアップしています"
-
-#: ../src/Package.vala:210
-msgid "Obsoleting packages"
-msgstr "パッケージを不要にしています"
-
-#: ../src/Package.vala:212
-msgid "Resolving dependencies"
-msgstr "依存関係を解決しています"
-
-#: ../src/Package.vala:214
-msgid "Checking signatures"
-msgstr "シグネチャーを確認しています"
-
-#: ../src/Package.vala:216
-msgid "Testing changes"
-msgstr "変更をテストしています"
-
-#: ../src/Package.vala:218
-msgid "Committing changes"
-msgstr "変更をコミットしています"
-
-#: ../src/Package.vala:220
-msgid "Requesting data"
-msgstr "データを要求しています"
-
-#: ../src/Package.vala:222 ../src/Package.vala:455
-msgid "Finished"
-msgstr "完了しました"
-
-#: ../src/Package.vala:224
-msgid "Cancelling"
-msgstr "キャンセルしています"
-
-#: ../src/Package.vala:226
-msgid "Downloading repository information"
-msgstr "レポジトリの情報をダウンロードしています"
-
-#: ../src/Package.vala:228
-msgid "Downloading list of packages"
-msgstr "パッケージのリストをダウンロードしています"
-
-#: ../src/Package.vala:230
-msgid "Downloading file lists"
-msgstr "ファイルリストをダウンロードしています"
-
-#: ../src/Package.vala:232
-msgid "Downloading lists of changes"
-msgstr "変更のリストをダウンロードしています"
-
-#: ../src/Package.vala:234
-msgid "Downloading groups"
-msgstr "グループをダウンロードしています"
-
-#: ../src/Package.vala:236
-msgid "Downloading update information"
-msgstr "アップデート情報をダウンロードしています"
-
-#: ../src/Package.vala:238
-msgid "Repackaging files"
-msgstr "ファイルを再構築しています"
-
-#: ../src/Package.vala:240
-msgid "Loading cache"
-msgstr "キャッシュを読み込んでいます"
-
-#: ../src/Package.vala:242
-msgid "Scanning applications"
-msgstr "アプリケーションをスキャンしています"
-
-#: ../src/Package.vala:244
-msgid "Generating package lists"
-msgstr "パッケージリストを作成しています"
-
-#: ../src/Package.vala:246
-msgid "Waiting for package manager lock"
-msgstr "パッケージマネージャーのロックを待機しています"
-
-#: ../src/Package.vala:248
-msgid "Waiting for authentication"
-msgstr "認証を待機しています"
-
-#: ../src/Package.vala:250
-msgid "Updating running applications"
-msgstr "実行中のアプリケーションをアップデートしています"
-
-#: ../src/Package.vala:252
-msgid "Checking applications in use"
-msgstr "使用中のアプリケーションを確認しています"
-
-#: ../src/Package.vala:254
-msgid "Checking libraries in use"
-msgstr "使用中のライブラリを確認しています"
-
-#: ../src/Package.vala:256
-msgid "Copying files"
-msgstr "ファイルをコピーしています"
-
-#: ../src/Package.vala:259
-msgid "Installing"
-msgstr "インストールしています"
-
-#: ../src/Package.vala:457
-msgid "Cancelled"
-msgstr "キャンセルしました"
-
-#: ../src/Package.vala:460
-msgid "Failed"
-msgstr "失敗しました"
-
-#: ../src/Package.vala:463 ../src/DetailedView.vala:32
-#: ../src/DetailedView.vala:34 ../src/DetailedView.vala:37
+#: src/DetailedView.vala:32 src/DetailedView.vala:34 src/DetailedView.vala:37
+#: src/Package.vala:463
 msgid "Unknown"
 msgstr "不明"
 
-#: ../src/MainWindow.vala:95
-msgid "Open…"
-msgstr "開く…"
-
-#: ../src/MainWindow.vala:103
-msgid "Go back"
-msgstr "戻る"
-
-#: ../src/MainWindow.vala:120
-msgid "Install some apps"
-msgstr "アプリをインストールしましょう"
-
-#: ../src/MainWindow.vala:120
-msgid "Drag and drop .%s files or open them to begin installation."
-msgstr "インストールを開始するには .%s ファイルをドラッグアンドドロップするか開いてください。"
-
-#: ../src/MainWindow.vala:122 ../src/MainWindow.vala:454
-msgid "Open"
-msgstr "開く"
-
-#: ../src/MainWindow.vala:122
-msgid "Browse to open a single file"
-msgstr "ブラウズしてファイルを一つ開きます"
-
-#: ../src/MainWindow.vala:191
-msgid "There is %u operation unfinished"
-msgstr "完了していない操作が %u あります"
-
-#: ../src/MainWindow.vala:191
-msgid "There are %u operations unfinished"
-msgstr "完了していない操作が %u あります"
-
-#: ../src/MainWindow.vala:192
-msgid "There Are Ongoing Operations"
-msgstr "進行中の操作があります"
-
-#: ../src/MainWindow.vala:192
-msgid "%s. Quitting will cancel all remaining transactions."
-msgstr "%s。終了するとすべての残っている処理をキャンセルします。"
-
-#: ../src/MainWindow.vala:193
-msgid "Do Not Quit"
-msgstr "終了しない"
-
-#: ../src/MainWindow.vala:195
-msgid "Quit Anyway"
-msgstr "とにかく終了する"
-
-#: ../src/MainWindow.vala:284
-msgid "Installation Failed"
-msgstr "インストールが失敗しました"
-
-#: ../src/MainWindow.vala:286
-msgid "Uninstallation Failed"
-msgstr "アンインストールが失敗しました"
-
-#: ../src/MainWindow.vala:290 ../src/MainWindow.vala:431
-msgid "Close"
-msgstr "閉じる"
-
-#: ../src/MainWindow.vala:309 ../src/MainWindow.vala:316
-msgid "Installation succeeded"
-msgstr "インストールが成功しました"
-
-#: ../src/MainWindow.vala:310
-msgid "%s has been successfully installed"
-msgstr "%s のインストールが成功しました"
-
-#: ../src/MainWindow.vala:312 ../src/MainWindow.vala:319
-msgid "Uninstallation succeeded"
-msgstr "アンインストールが成功しました"
-
-#: ../src/MainWindow.vala:313
-msgid "%s has been successfully uninstalled"
-msgstr "%s のアンインストールが成功しました"
-
-#: ../src/MainWindow.vala:317
-msgid "All packages have been successfully installed"
-msgstr "すべてのパッケージのインストールが成功しました"
-
-#: ../src/MainWindow.vala:320
-msgid "All packages have been successfully uninstalled"
-msgstr "すべてのパッケージのアンインストールが成功しました"
-
-#: ../src/MainWindow.vala:331
-msgid "Load from Downloads"
-msgstr "ダウンロードから読み込む"
-
-#: ../src/MainWindow.vala:331
-msgid "Load .%s files from your Downloads folder"
-msgstr "ダウンロードフォルダから .%s ファイルを読み込む"
-
-#: ../src/MainWindow.vala:365
-msgid "<b>%s</b> is not a package"
-msgstr "<b>%s</b> はパッケージではありません"
-
-#: ../src/MainWindow.vala:404
-msgid "<b>%s</b> is not a valid package"
-msgstr "<b>%s</b> は有効なパッケージではありません"
-
-#: ../src/MainWindow.vala:430
-msgid "Some Packages Could Not Be Added"
-msgstr "追加できなかったパッケージがあります"
-
-#: ../src/MainWindow.vala:440
-msgid "Packages"
-msgstr "パッケージ"
-
-#: ../src/MainWindow.vala:446
-msgid "All Files"
-msgstr "すべてのファイル"
-
-#: ../src/MainWindow.vala:452
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: ../src/DetailedView.vala:44
+#: src/DetailedView.vala:44
 msgid "Homepage"
 msgstr "ホームページ"
 
-#: ../src/DetailedView.vala:63
+#. TRANSLATORS:
+#. this string is formatted as: "version: `package-version` • `package-installed-size`"
+#: src/DetailedView.vala:63
+#, c-format
 msgid "version %s • %s"
 msgstr "バージョン %s • %s"
 
-#: ../src/PackageRow.vala:94
+#: src/MainWindow.vala:95
+msgid "Open…"
+msgstr "開く…"
+
+#: src/MainWindow.vala:103
+msgid "Go back"
+msgstr "戻る"
+
+#: src/MainWindow.vala:121
+msgid "Install some apps"
+msgstr "アプリをインストールしましょう"
+
+#: src/MainWindow.vala:121
+#, c-format
+msgid "Drag and drop .%s files or open them to begin installation."
+msgstr ""
+"インストールを開始するには、.%s ファイルをドラッグアンドドロップするか開いて"
+"ください。"
+
+#: src/MainWindow.vala:123 src/MainWindow.vala:457
+msgid "Open"
+msgstr "開く"
+
+#: src/MainWindow.vala:123
+msgid "Browse to open a single file"
+msgstr "ブラウズしてファイルを一つ開きます"
+
+#: src/MainWindow.vala:192
+#, c-format
+msgid "There is %u operation unfinished"
+msgstr "完了していない操作が %u 件あります"
+
+#: src/MainWindow.vala:192
+#, c-format
+msgid "There are %u operations unfinished"
+msgstr "完了していない操作が %u 件あります"
+
+#: src/MainWindow.vala:193
+msgid "There Are Ongoing Operations"
+msgstr "進行中の操作があります"
+
+#: src/MainWindow.vala:194
+#, c-format
+msgid "%s. Quitting will cancel all remaining transactions."
+msgstr "%s。終了すると、すべての残っている処理をキャンセルします。"
+
+#: src/MainWindow.vala:197
+msgid "Do Not Quit"
+msgstr "終了しない"
+
+#: src/MainWindow.vala:199
+msgid "Quit Anyway"
+msgstr "とにかく終了"
+
+#: src/MainWindow.vala:288
+msgid "Installation Failed"
+msgstr "インストールに失敗しました"
+
+#: src/MainWindow.vala:290
+msgid "Uninstallation Failed"
+msgstr "アンインストールに失敗しました"
+
+#: src/MainWindow.vala:312 src/MainWindow.vala:319
+msgid "Installation succeeded"
+msgstr "インストールに成功しました"
+
+#: src/MainWindow.vala:313
+#, c-format
+msgid "%s has been successfully installed"
+msgstr "%s は正しくインストールされました"
+
+#: src/MainWindow.vala:315 src/MainWindow.vala:322
+msgid "Uninstallation succeeded"
+msgstr "アンインストールに成功しました"
+
+#: src/MainWindow.vala:316
+#, c-format
+msgid "%s has been successfully uninstalled"
+msgstr "%s は正しくアンインストールされました"
+
+#: src/MainWindow.vala:320
+msgid "All packages have been successfully installed"
+msgstr "すべてのパッケージが正しくインストールされました"
+
+#: src/MainWindow.vala:323
+msgid "All packages have been successfully uninstalled"
+msgstr "すべてのパッケージが正しくアンインストールされました"
+
+#: src/MainWindow.vala:334
+msgid "Load from Downloads"
+msgstr "ダウンロードフォルダーから読み込む"
+
+#: src/MainWindow.vala:334
+#, c-format
+msgid "Load .%s files from your Downloads folder"
+msgstr "ダウンロードフォルダーから .%s ファイルを読み込みます"
+
+#: src/MainWindow.vala:368
+#, c-format
+msgid "<b>%s</b> is not a package"
+msgstr "<b>%s</b> はパッケージではありません"
+
+#: src/MainWindow.vala:407
+#, c-format
+msgid "<b>%s</b> is not a valid package"
+msgstr "<b>%s</b> は有効なパッケージではありません"
+
+#: src/MainWindow.vala:433
+msgid "Some Packages Could Not Be Added"
+msgstr "追加できなかったパッケージがあります"
+
+#: src/MainWindow.vala:443
+msgid "Packages"
+msgstr "パッケージ"
+
+#: src/MainWindow.vala:449
+msgid "All Files"
+msgstr "すべてのファイル"
+
+#: src/MainWindow.vala:455
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: src/Package.vala:190
+msgid "Starting"
+msgstr "開始しています"
+
+#: src/Package.vala:192
+msgid "Waiting"
+msgstr "待機しています"
+
+#: src/Package.vala:194
+msgid "Running"
+msgstr "実行しています"
+
+#: src/Package.vala:196
+msgid "Querying"
+msgstr "問い合わせています"
+
+#: src/Package.vala:198
+msgid "Getting information"
+msgstr "情報を取得しています"
+
+#: src/Package.vala:200
+msgid "Removing packages"
+msgstr "パッケージを削除しています"
+
+#: src/Package.vala:202
+msgid "Downloading"
+msgstr "ダウンロードしています"
+
+#: src/Package.vala:204
+msgid "Refreshing software list"
+msgstr "ソフトウェアリストを更新しています"
+
+#: src/Package.vala:206
+msgid "Installing updates"
+msgstr "アップデートをインストールしています"
+
+#: src/Package.vala:208
+msgid "Cleaning up packages"
+msgstr "パッケージをクリーンアップしています"
+
+#: src/Package.vala:210
+msgid "Obsoleting packages"
+msgstr "パッケージを不要にしています"
+
+#: src/Package.vala:212
+msgid "Resolving dependencies"
+msgstr "依存関係を解決しています"
+
+#: src/Package.vala:214
+msgid "Checking signatures"
+msgstr "シグネチャーを確認しています"
+
+#: src/Package.vala:216
+msgid "Testing changes"
+msgstr "変更をテストしています"
+
+#: src/Package.vala:218
+msgid "Committing changes"
+msgstr "変更をコミットしています"
+
+#: src/Package.vala:220
+msgid "Requesting data"
+msgstr "データを要求しています"
+
+#: src/Package.vala:222 src/Package.vala:455
+msgid "Finished"
+msgstr "完了しました"
+
+#: src/Package.vala:224
+msgid "Cancelling"
+msgstr "キャンセルしています"
+
+#: src/Package.vala:226
+msgid "Downloading repository information"
+msgstr "レポジトリの情報をダウンロードしています"
+
+#: src/Package.vala:228
+msgid "Downloading list of packages"
+msgstr "パッケージのリストをダウンロードしています"
+
+#: src/Package.vala:230
+msgid "Downloading file lists"
+msgstr "ファイルリストをダウンロードしています"
+
+#: src/Package.vala:232
+msgid "Downloading lists of changes"
+msgstr "変更のリストをダウンロードしています"
+
+#: src/Package.vala:234
+msgid "Downloading groups"
+msgstr "グループをダウンロードしています"
+
+#: src/Package.vala:236
+msgid "Downloading update information"
+msgstr "アップデート情報をダウンロードしています"
+
+#: src/Package.vala:238
+msgid "Repackaging files"
+msgstr "ファイルを再構築しています"
+
+#: src/Package.vala:240
+msgid "Loading cache"
+msgstr "キャッシュを読み込んでいます"
+
+#: src/Package.vala:242
+msgid "Scanning applications"
+msgstr "アプリケーションをスキャンしています"
+
+#: src/Package.vala:244
+msgid "Generating package lists"
+msgstr "パッケージリストを作成しています"
+
+#: src/Package.vala:246
+msgid "Waiting for package manager lock"
+msgstr "パッケージマネージャーのロックを待機しています"
+
+#: src/Package.vala:248
+msgid "Waiting for authentication"
+msgstr "認証を待機しています"
+
+#: src/Package.vala:250
+msgid "Updating running applications"
+msgstr "実行中のアプリケーションをアップデートしています"
+
+#: src/Package.vala:252
+msgid "Checking applications in use"
+msgstr "使用中のアプリケーションを確認しています"
+
+#: src/Package.vala:254
+msgid "Checking libraries in use"
+msgstr "使用中のライブラリを確認しています"
+
+#: src/Package.vala:256
+msgid "Copying files"
+msgstr "ファイルをコピーしています"
+
+#: src/Package.vala:259
+msgid "Installing"
+msgstr "インストールしています"
+
+#: src/Package.vala:457
+msgid "Cancelled"
+msgstr "キャンセルしました"
+
+#: src/Package.vala:460
+msgid "Failed"
+msgstr "失敗しました"
+
+#: src/PackageListView.vala:49 src/PackageRow.vala:165
+msgid "Install"
+msgstr "インストール"
+
+#: src/PackageListView.vala:153
+#, c-format
+msgid "Total installed size: %s"
+msgstr "合計インストールサイズ: %s"
+
+#: src/PackageRow.vala:94
 msgid "Remove from list"
 msgstr "リストから削除"
 
-#: ../src/PackageRow.vala:162
+#: src/PackageRow.vala:162
 msgid "Uninstall"
 msgstr "アンインストール"
 
-#: ../src/PackageRow.vala:170
+#: src/PackageRow.vala:170
 msgid "Update"
 msgstr "アップデート"
 
-#: ../src/PackageRow.vala:175
+#: src/PackageRow.vala:175
 msgid "Downgrade"
 msgstr "ダウングレード"
+
+#~ msgid "Close"
+#~ msgstr "閉じる"


### PR DESCRIPTION
### Changes Summary

* Fix verbose translations
* Make translations readable and easy-to-understand (e.g. adding comma, using easy-to-understand expressions)
