### PR TITLE
added package version number checking of last part

### DIFF
--- a/src/Package.vala
+++ b/src/Package.vala
@@ -283,6 +283,14 @@ public class Eddy.Package : Object {
         int length = int.max (aparts.length, bparts.length);
         for (int i = 0; i < length; i++) {
             int rc = strcmp (aparts[i], bparts[i]);
+            if(i == length -1 ){              
+                if(bparts[i] > aparts[i]){
+                    return 1;
+                }      
+                else if(bparts[i] < aparts[i]){
+                    return -1;
+                }                             
+            }
             if (rc < 0) {
                 return -1;
             } else if (rc > 0) {


### PR DESCRIPTION
Adding  length check of last '.' separated group of package version number. Package versions schemes like 0.0.9 are considered higher and upgradable when compared to a package version of 0.0.10 with out the check.