### PR TITLE
package version check

### DIFF
--- a/src/Package.vala
+++ b/src/Package.vala
@@ -283,7 +283,7 @@ public class Eddy.Package : Object {
         int length = int.max (aparts.length, bparts.length);
         for (int i = 0; i < length; i++) {
             int rc = strcmp (aparts[i], bparts[i]);
-            if(i == length -1 ){              
+            if (i == length - 1) {              
                 if(bparts[i] > aparts[i]){
                     return 1;
                 }      

--- a/src/Package.vala
+++ b/src/Package.vala
@@ -284,7 +284,7 @@ public class Eddy.Package : Object {
         for (int i = 0; i < length; i++) {
             int rc = strcmp (aparts[i], bparts[i]);
             if (i == length - 1) {              
-                if(bparts[i] > aparts[i]){
+                if (bparts[i] > aparts[i]) {
                     return 1;
                 }      
                 else if(bparts[i] < aparts[i]){

--- a/src/Package.vala
+++ b/src/Package.vala
@@ -287,7 +287,7 @@ public class Eddy.Package : Object {
                 if (bparts[i] > aparts[i]) {
                     return 1;
                 }      
-                else if(bparts[i] < aparts[i]){
+                else if (bparts[i] < aparts[i]) {
                     return -1;
                 }                             
             }


### PR DESCRIPTION
Current version checking does not account for certain version schemes. When version ending in .9 is compared to version .10 eddy asks to downgrade to .10. Added an additional check of length after last "." to account for these cases.