### PR TITLE
Flatpak: Upgrade elementary SDK to 6.1

### DIFF
--- a/com.github.donadigo.eddy.yml
+++ b/com.github.donadigo.eddy.yml
@@ -1,6 +1,6 @@
 app-id: com.github.donadigo.eddy
 runtime: io.elementary.Platform
-runtime-version: '6'
+runtime-version: '6.1'
 sdk: io.elementary.Sdk
 command: com.github.donadigo.eddy
 finish-args:


### PR DESCRIPTION
As requested in https://github.com/elementary/appcenter-reviews/pull/285#pullrequestreview-843090356
