### PR TITLE
Fix translation is not loaded in Flatpak

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,13 +4,13 @@ gnome = import('gnome')
 i18n = import('i18n')
 
 conf = configuration_data()
+conf.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
 conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
-configure_file(output: 'config.h', configuration: conf)
-config_h_dir = include_directories('.')
-
-c_args = [
-  '-include', 'config.h'
-]
+config_file = configure_file(
+  input: 'src' / 'Config.vala.in',
+  output: '@BASENAME@',
+  configuration: conf
+)
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 add_project_arguments('-DI_KNOW_THE_PACKAGEKIT_GLIB2_API_IS_SUBJECT_TO_CHANGE', language : 'c')
@@ -33,6 +33,7 @@ endif
 
 executable(
     meson.project_name(),
+    config_file,
     'src/Application.vala',
     'src/AppSettings.vala',
     'src/Constants.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,6 +26,11 @@ public class Eddy.Application : Gtk.Application {
 
         application_id = "com.github.donadigo.eddy";
 
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (GETTEXT_PACKAGE);
+
         control = new Pk.Control ();
 
         var settings = AppSettings.get_default ();

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
Essentially the same fix with https://github.com/donadigo/appeditor/pull/119

## Before
![Screenshot from 2022-01-04 20-37-12](https://user-images.githubusercontent.com/26003928/148053544-0d81db5c-3e43-4b3d-b142-f61ee2be274d.png)

The app always displays in English, regardless of the system language (for me Japanese).

## After
![Screenshot from 2022-01-04 20-32-32](https://user-images.githubusercontent.com/26003928/148053644-7e6a1670-64a8-4f2b-8a75-640683e7c294.png)

The app now respects the system language.
