### PR TITLE
AppData: Fix deprecated mimetypes tags

### DIFF
--- a/data/com.github.donadigo.eddy.appdata.xml.in
+++ b/data/com.github.donadigo.eddy.appdata.xml.in
@@ -19,6 +19,8 @@
   </description>
   <provides>
     <binary>com.github.donadigo.eddy</binary>
+    <mediatype>application/x-debian-package</mediatype>
+    <mediatype>application/vnd.debian.binary-package</mediatype>
   </provides>
   <releases>
       <release version="1.3.2" date="2022-01-03">
@@ -238,10 +240,6 @@
       <image>https://raw.githubusercontent.com/donadigo/eddy/master/Screenshot_3.png</image>
     </screenshot>
   </screenshots>
-  ​<mimetypes>
-    <mimetype>application/x-debian-package</mimetype>
-    <mimetype>application/vnd.debian.binary-package</mimetype>
-  </mimetypes>
 
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>


### PR DESCRIPTION
Fixes #118

Seems like the toplevel `<mimetypes>` tags are deprecated in the future version of appstream validatation: https://appstream.debian.org/sid/main/issues/antimicro.html
