### PR TITLE
PackageRow: Escape package description

### DIFF
--- a/src/PackageRow.vala
+++ b/src/PackageRow.vala
@@ -52,7 +52,7 @@ public class Eddy.PackageRow : Gtk.ListBoxRow {
         var package_image = new Gtk.Image.from_icon_name ("package", Gtk.IconSize.DND);
         package_image.valign = Gtk.Align.START;
 
-        var summary_label = new Gtk.Label ("<b>%s</b>".printf (package.summary));
+        var summary_label = new Gtk.Label ("<b>%s</b>".printf (Markup.escape_text (package.summary)));
         summary_label.wrap = true;
         summary_label.wrap_mode = Pango.WrapMode.WORD_CHAR;
         summary_label.use_markup = true;


### PR DESCRIPTION
Fixes #135

### Before
![VirtualBox_elementary OS Daily_09_05_2023_20_53_33](https://github.com/donadigo/eddy/assets/26003928/18112e37-5456-4c8a-93ac-adeda7b99969)

### After
![VirtualBox_elementary OS Daily_09_05_2023_21_59_26](https://github.com/donadigo/eddy/assets/26003928/cb453d84-bf87-4b5e-bba8-f7fed379a565)
