### PR TITLE
AppData: Add translation info

### DIFF
--- a/data/com.github.donadigo.eddy.appdata.xml.in
+++ b/data/com.github.donadigo.eddy.appdata.xml.in
@@ -2,6 +2,7 @@
 <!-- Copyright (c) 2017 Adam Bieńkowski (https://github.com/donadigo/eddy) -->
 <component type="desktop">
   <id>com.github.donadigo.eddy</id>
+  <translation type="gettext">com.github.donadigo.eddy</translation>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Eddy</name>


### PR DESCRIPTION
This fixes the following warning about no translation info provided in AppCenter:

![スクリーンショット 2023-08-07 23 59 49](https://github.com/donadigo/eddy/assets/26003928/d4d3bb19-210d-46e3-b937-60f41a338215)
